### PR TITLE
KMCP CLI 

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -175,7 +175,15 @@ var _ = ginkgo.Describe("Manager", ginkgo.Ordered, func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to build kmcp CLI")
 
 			ginkgo.By("creating a knowledge-assistant project using kmcp CLI")
-			cmd = exec.Command("dist/kmcp", "init", projectDir, "--framework", "fastmcp-python", "--force", "--namespace", namespace)
+			cmd = exec.Command(
+				"dist/kmcp",
+				"init", projectDir,
+				"--framework",
+				"fastmcp-python",
+				"--force",
+				"--namespace",
+				namespace,
+			)
 			_, err = utils.Run(cmd)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create knowledge-assistant project")
 
@@ -205,7 +213,17 @@ var _ = ginkgo.Describe("Manager", ginkgo.Ordered, func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to load Docker image into Kind cluster")
 
 			ginkgo.By("deploying the knowledge-assistant MCP server using kmcp CLI")
-			cmd = exec.Command("dist/kmcp", "deploy", "mcp", "-f", fmt.Sprintf("%s/kmcp.yaml", projectDir), "-n", namespace, "--environment", "local")
+			cmd = exec.Command(
+				"dist/kmcp",
+				"deploy",
+				"mcp",
+				"-f",
+				fmt.Sprintf("%s/kmcp.yaml", projectDir),
+				"-n",
+				namespace,
+				"--environment",
+				"local",
+			)
 			_, err = utils.Run(cmd)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to deploy knowledge-assistant MCP server")
 


### PR DESCRIPTION
- Add a CLI `kmcp` that allows users to create a mcp project and deploy it to the kubernetes cluster
- Updated e2e test to use mcp server built using `kmcp`
- Add `kmcp` binary to release pipeline

Demo script that will create an mcp server with an echo tool deployed to kind which can be connected to using mcp inspector.
 
Last updated 7/23/25 - 
[setup-kind-demo.sh.zip](https://github.com/user-attachments/files/21399858/setup-kind-demo.2.sh.zip)
