### PR TITLE
Fix go modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,7 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 .PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...
+	goimports -local "github.com/kgateway-dev/kmcp" -w .
 
 .PHONY: vet
 vet: ## Run go vet against code.
@@ -181,7 +182,7 @@ build: manifests generate fmt vet ## Build manager binary.
 .PHONY: build-cli
 build-cli: fmt vet ## Build kmcp CLI binary.
 	mkdir -p $(DIST_FOLDER)
-	go build -ldflags="-X 'kagent.dev/kmcp/cmd/kmcp/cmd.Version=$(VERSION)'" -o $(DIST_FOLDER)/kmcp cmd/kmcp/main.go
+	go build -ldflags="-X 'github.com/kagent-dev/kmcp/cmd/kmcp/cmd.Version=$(VERSION)'" -o $(DIST_FOLDER)/kmcp cmd/kmcp/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,9 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: fmt
-fmt: ## Run go fmt against code.
+fmt: goimports ## Run go fmt against code.
 	go fmt ./...
-	goimports -local "github.com/kgateway-dev/kmcp" -w .
+	$(GOIMPORTS) -local "github.com/kgateway-dev/kmcp" -w .
 
 .PHONY: vet
 vet: ## Run go vet against code.
@@ -216,6 +216,7 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+GOIMPORTS ?= $(LOCALBIN)/goimports
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.5.0
@@ -225,6 +226,7 @@ ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 GOLANGCI_LINT_VERSION ?= v1.63.4
+GOIMPORTS_VERSION ?= v0.26.0
 
 
 .PHONY: controller-gen
@@ -249,6 +251,11 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+.PHONY: goimports
+goimports: $(GOIMPORTS) ## Download goimports locally if necessary.
+$(GOIMPORTS): $(LOCALBIN)
+	$(call go-install-tool,$(GOIMPORTS),golang.org/x/tools/cmd/goimports,$(GOIMPORTS_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/PROJECT
+++ b/PROJECT
@@ -6,7 +6,7 @@ domain: kagent.dev
 layout:
 - go.kubebuilder.io/v4
 projectName: kmcp
-repo: kagent.dev/kmcp
+repo: github.com/kagent-dev/kmcp
 resources:
 - api:
     crdVersion: v1
@@ -14,6 +14,6 @@ resources:
   controller: true
   domain: kagent.dev
   kind: MCPServer
-  path: kagent.dev/kmcp/api/v1alpha1
+  path: github.com/kagent-dev/kmcp/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/cmd/kmcp/cmd/add_tool.go
+++ b/cmd/kmcp/cmd/add_tool.go
@@ -6,11 +6,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"kagent.dev/kmcp/pkg/templates"
+	"github.com/kagent-dev/kmcp/pkg/templates"
 
+	"github.com/kagent-dev/kmcp/pkg/frameworks"
+	"github.com/kagent-dev/kmcp/pkg/manifest"
 	"github.com/spf13/cobra"
-	"kagent.dev/kmcp/pkg/frameworks"
-	"kagent.dev/kmcp/pkg/manifest"
 )
 
 var addToolCmd = &cobra.Command{

--- a/cmd/kmcp/cmd/build.go
+++ b/cmd/kmcp/cmd/build.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/kagent-dev/kmcp/pkg/build"
 	"github.com/spf13/cobra"
-	"kagent.dev/kmcp/pkg/build"
 )
 
 var buildCmd = &cobra.Command{

--- a/cmd/kmcp/cmd/deploy.go
+++ b/cmd/kmcp/cmd/deploy.go
@@ -7,12 +7,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kagent-dev/kmcp/api/v1alpha1"
+	"github.com/kagent-dev/kmcp/pkg/manifest"
+	"github.com/kagent-dev/kmcp/pkg/wellknown"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"kagent.dev/kmcp/api/v1alpha1"
-	"kagent.dev/kmcp/pkg/manifest"
-	"kagent.dev/kmcp/pkg/wellknown"
 	"sigs.k8s.io/yaml"
 )
 

--- a/cmd/kmcp/cmd/init.go
+++ b/cmd/kmcp/cmd/init.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"kagent.dev/kmcp/pkg/frameworks"
-	"kagent.dev/kmcp/pkg/manifest"
-	"kagent.dev/kmcp/pkg/templates"
+	"github.com/kagent-dev/kmcp/pkg/frameworks"
+	"github.com/kagent-dev/kmcp/pkg/manifest"
+	"github.com/kagent-dev/kmcp/pkg/templates"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/kmcp/cmd/init_go.go
+++ b/cmd/kmcp/cmd/init_go.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/kagent-dev/kmcp/pkg/templates"
 	"github.com/spf13/cobra"
-	"kagent.dev/kmcp/pkg/templates"
 )
 
 var (

--- a/cmd/kmcp/cmd/run.go
+++ b/cmd/kmcp/cmd/run.go
@@ -7,8 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/kagent-dev/kmcp/pkg/manifest"
 	"github.com/spf13/cobra"
-	"kagent.dev/kmcp/pkg/manifest"
 )
 
 var runCmd = &cobra.Command{

--- a/cmd/kmcp/main.go
+++ b/cmd/kmcp/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"kagent.dev/kmcp/cmd/kmcp/cmd"
+	"github.com/kagent-dev/kmcp/cmd/kmcp/cmd"
 )
 
 func main() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,8 +37,8 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	kagentdevv1alpha1 "kagent.dev/kmcp/api/v1alpha1"
-	"kagent.dev/kmcp/internal/controller"
+	kagentdevv1alpha1 "github.com/kagent-dev/kmcp/api/v1alpha1"
+	"github.com/kagent-dev/kmcp/internal/controller"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,15 @@
-module kagent.dev/kmcp
+module github.com/kagent-dev/kmcp
 
 go 1.24.0
 
 toolchain go1.24.3
 
-godebug default=go1.23
-
 require (
-	github.com/kagent-dev/kmcp v0.0.0-00010101000000-000000000000
 	github.com/mark3labs/mcp-go v0.33.0
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1
 	github.com/spf13/cobra v1.8.1
+	github.com/stoewer/go-strcase v1.3.0
 	golang.org/x/text v0.19.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.32.0
@@ -66,7 +64,6 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect
@@ -104,5 +101,3 @@ require (
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 )
-
-replace github.com/kagent-dev/kmcp => ./

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"kagent.dev/kmcp/pkg/agentgateway"
+	"github.com/kagent-dev/kmcp/pkg/agentgateway"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,8 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	kagentdevv1alpha1 "github.com/kagent-dev/kmcp/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kagentdevv1alpha1 "kagent.dev/kmcp/api/v1alpha1"
 )
 
 // MCPServerReconciler reconciles a MCPServer object

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -28,7 +28,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kagentdevv1alpha1 "kagent.dev/kmcp/api/v1alpha1"
+	kagentdevv1alpha1 "github.com/kagent-dev/kmcp/api/v1alpha1"
 )
 
 var _ = ginkgo.Describe("MCPServer Controller", func() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -32,7 +32,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	kagentdevv1alpha1 "kagent.dev/kmcp/api/v1alpha1"
+	kagentdevv1alpha1 "github.com/kagent-dev/kmcp/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/pkg/agentgateway/agentgateway_translator.go
+++ b/pkg/agentgateway/agentgateway_translator.go
@@ -7,11 +7,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/kagent-dev/kmcp/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"kagent.dev/kmcp/api/v1alpha1"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/frameworks/common/base_generator.go
+++ b/pkg/frameworks/common/base_generator.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/stoewer/go-strcase"
 
+	"github.com/kagent-dev/kmcp/pkg/templates"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-	"kagent.dev/kmcp/pkg/templates"
 )
 
 // Base Generator for MCP projects

--- a/pkg/frameworks/frameworks.go
+++ b/pkg/frameworks/frameworks.go
@@ -3,9 +3,9 @@ package frameworks
 import (
 	"fmt"
 
-	"kagent.dev/kmcp/pkg/frameworks/golang"
-	"kagent.dev/kmcp/pkg/frameworks/python"
-	"kagent.dev/kmcp/pkg/templates"
+	"github.com/kagent-dev/kmcp/pkg/frameworks/golang"
+	"github.com/kagent-dev/kmcp/pkg/frameworks/python"
+	"github.com/kagent-dev/kmcp/pkg/templates"
 )
 
 // Generator defines the interface for a framework-specific generator.

--- a/pkg/frameworks/golang/generator.go
+++ b/pkg/frameworks/golang/generator.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/kagent-dev/kmcp/pkg/frameworks/common"
+	"github.com/kagent-dev/kmcp/pkg/templates"
 	"github.com/stoewer/go-strcase"
-	"kagent.dev/kmcp/pkg/frameworks/common"
-	"kagent.dev/kmcp/pkg/templates"
 )
 
 //go:embed all:templates

--- a/pkg/frameworks/python/generator.go
+++ b/pkg/frameworks/python/generator.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kagent-dev/kmcp/pkg/frameworks/common"
+	"github.com/kagent-dev/kmcp/pkg/templates"
 	"github.com/stoewer/go-strcase"
-	"kagent.dev/kmcp/pkg/frameworks/common"
-	"kagent.dev/kmcp/pkg/templates"
 )
 
 //go:embed all:templates

--- a/pkg/templates/generator.go
+++ b/pkg/templates/generator.go
@@ -1,6 +1,6 @@
 package templates
 
-import "kagent.dev/kmcp/pkg/manifest"
+import "github.com/kagent-dev/kmcp/pkg/manifest"
 
 // ProjectConfig contains all the information needed to generate a project
 type ProjectConfig struct {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -24,7 +24,7 @@ import (
 	ginkgo "github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"
 
-	"kagent.dev/kmcp/test/utils"
+	"github.com/kagent-dev/kmcp/test/utils"
 )
 
 var (

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -29,11 +29,11 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
+	"github.com/kagent-dev/kmcp/test/utils"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"kagent.dev/kmcp/test/utils"
 )
 
 // namespace where the project is deployed in


### PR DESCRIPTION
We had a `mod` that was not a real domain, which requires a `replace` which breaks `go install`. This uses the real github domain as the module.

Alternatively, we can use `kagent.dev/kmcp` IFF we go make that actually resolve the Go mod metadata properly