### PR TITLE
helm name override

### DIFF
--- a/helm/kmcp/templates/_helpers.tpl
+++ b/helm/kmcp/templates/_helpers.tpl
@@ -1,3 +1,5 @@
+
+
 {{/*
 Expand the name of the chart.
 */}}
@@ -7,11 +9,19 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "kmcp.fullname" -}}
-{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- if not .Values.nameOverride }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
+{{- end }}
+{{- end }}
+
 
 {{/*
 Create chart name and version as used by the chart label.
@@ -39,17 +49,6 @@ Selector labels
 app.kubernetes.io/name: {{ include "kmcp.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 control-plane: controller-manager
-{{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "kmcp.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (printf "%s-controller-manager" (include "kmcp.fullname" .)) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/kmcp/templates/_helpers.tpl
+++ b/helm/kmcp/templates/_helpers.tpl
@@ -48,7 +48,7 @@ Selector labels
 {{- define "kmcp.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "kmcp.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-control-plane: controller-manager
+control-plane: controller
 {{- end }}
 
 {{/*

--- a/helm/kmcp/templates/deployment.yaml
+++ b/helm/kmcp/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-controller-manager
+  name: {{ include "kmcp.fullname" . }}-controller
   namespace: {{ include "kmcp.namespace" . }}
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}
@@ -24,7 +24,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "kmcp.serviceAccountName" . }}
+      serviceAccountName: {{ include "kmcp.fullname" . }}-controller
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm/kmcp/templates/rbac/clusterrole.yaml
+++ b/helm/kmcp/templates/rbac/clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-manager-role
+  name: {{ include "kmcp.fullname" . }}-controller-role
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}
 rules:

--- a/helm/kmcp/templates/rbac/clusterrolebinding.yaml
+++ b/helm/kmcp/templates/rbac/clusterrolebinding.yaml
@@ -2,15 +2,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-manager-rolebinding
+  name: {{ include "kmcp.fullname" . }}-controller-rolebinding
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-manager-role
+  name: {{ include "kmcp.fullname" . }}-controller-role
 subjects:
 - kind: ServiceAccount
-  name: {{ include "kmcp.serviceAccountName" . }}
+  name: {{ include "kmcp.fullname" . }}-controller
   namespace: {{ include "kmcp.namespace" . }}
 {{- end }} 

--- a/helm/kmcp/templates/rbac/leader-election-role.yaml
+++ b/helm/kmcp/templates/rbac/leader-election-role.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-leader-election-role
+  name: {{ include "kmcp.fullname" . }}-leader-election-role
   namespace: {{ include "kmcp.namespace" . }}
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}

--- a/helm/kmcp/templates/rbac/leader-election-rolebinding.yaml
+++ b/helm/kmcp/templates/rbac/leader-election-rolebinding.yaml
@@ -3,17 +3,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-leader-election-rolebinding
+  name: {{ include "kmcp.fullname" . }}-leader-election-rolebinding
   namespace: {{ include "kmcp.namespace" . }}
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-leader-election-role
+  name: {{ include "kmcp.fullname" . }}-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: {{ include "kmcp.serviceAccountName" . }}
+  name: {{ include "kmcp.fullname" . }}-controller
   namespace: {{ include "kmcp.namespace" . }}
 {{- end }}
 {{- end }} 

--- a/helm/kmcp/templates/rbac/metrics-auth-clusterrole.yaml
+++ b/helm/kmcp/templates/rbac/metrics-auth-clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-metrics-auth-role
+  name: {{ include "kmcp.fullname" . }}-metrics-auth-role
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}
 rules:

--- a/helm/kmcp/templates/rbac/metrics-auth-clusterrolebinding.yaml
+++ b/helm/kmcp/templates/rbac/metrics-auth-clusterrolebinding.yaml
@@ -3,16 +3,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-metrics-auth-rolebinding
+  name: {{ include "kmcp.fullname" . }}-metrics-auth-rolebinding
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-metrics-auth-role
+  name: {{ include "kmcp.fullname" . }}-metrics-auth-role
 subjects:
 - kind: ServiceAccount
-  name: {{ include "kmcp.serviceAccountName" . }}
+  name: {{ include "kmcp.fullname" . }}-controller
   namespace: {{ include "kmcp.namespace" . }}
 {{- end }}
 {{- end }} 

--- a/helm/kmcp/templates/rbac/metrics-reader-clusterrole.yaml
+++ b/helm/kmcp/templates/rbac/metrics-reader-clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-metrics-reader
+  name: {{ include "kmcp.fullname" . }}-metrics-reader
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}
 rules:

--- a/helm/kmcp/templates/rbac/serviceaccount.yaml
+++ b/helm/kmcp/templates/rbac/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "kmcp.serviceAccountName" . }}
+  name: {{ include "kmcp.fullname" . }}-controller
   namespace: {{ include "kmcp.namespace" . }}
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}

--- a/helm/kmcp/templates/service.yaml
+++ b/helm/kmcp/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-controller-manager-metrics-service
+  name: {{ include "kmcp.fullname" . }}-controller-metrics-service
   namespace: {{ include "kmcp.namespace" . }}
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}

--- a/helm/kmcp/tests/__snapshot__/deployment_test.yaml.snap
+++ b/helm/kmcp/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should create deployment with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -17,7 +17,7 @@ should create deployment with default values:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -25,7 +25,7 @@ should create deployment with default values:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -85,7 +85,7 @@ should include health probe ports when health probe enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -95,7 +95,7 @@ should include health probe ports when health probe enabled:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -103,7 +103,7 @@ should include health probe ports when health probe enabled:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -163,7 +163,7 @@ should include image pull secrets when specified:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -173,7 +173,7 @@ should include image pull secrets when specified:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -181,7 +181,7 @@ should include image pull secrets when specified:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -243,7 +243,7 @@ should include metrics port when metrics enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -253,7 +253,7 @@ should include metrics port when metrics enabled:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -261,7 +261,7 @@ should include metrics port when metrics enabled:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -321,7 +321,7 @@ should include node selector when specified:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -331,7 +331,7 @@ should include node selector when specified:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -339,7 +339,7 @@ should include node selector when specified:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -401,7 +401,7 @@ should include pod annotations when specified:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -411,7 +411,7 @@ should include pod annotations when specified:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -421,7 +421,7 @@ should include pod annotations when specified:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -481,7 +481,7 @@ should include tolerations when specified:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -491,7 +491,7 @@ should include tolerations when specified:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -499,7 +499,7 @@ should include tolerations when specified:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -564,7 +564,7 @@ should set custom replica count:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -574,7 +574,7 @@ should set custom replica count:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -582,7 +582,7 @@ should set custom replica count:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -642,7 +642,7 @@ should set custom resources:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -652,7 +652,7 @@ should set custom resources:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -660,7 +660,7 @@ should set custom resources:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -720,7 +720,7 @@ should set pod security context:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -730,7 +730,7 @@ should set pod security context:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -738,7 +738,7 @@ should set pod security context:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -798,7 +798,7 @@ should set security context:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -808,7 +808,7 @@ should set security context:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -816,7 +816,7 @@ should set security context:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -876,7 +876,7 @@ should set termination grace period:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -886,7 +886,7 @@ should set termination grace period:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -894,7 +894,7 @@ should set termination grace period:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:

--- a/helm/kmcp/tests/__snapshot__/deployment_test.yaml.snap
+++ b/helm/kmcp/tests/__snapshot__/deployment_test.yaml.snap
@@ -9,7 +9,7 @@ should create deployment with default values:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -73,7 +73,7 @@ should create deployment with default values:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should include health probe ports when health probe enabled:
@@ -87,7 +87,7 @@ should include health probe ports when health probe enabled:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -151,7 +151,7 @@ should include health probe ports when health probe enabled:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should include image pull secrets when specified:
@@ -165,7 +165,7 @@ should include image pull secrets when specified:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -231,7 +231,7 @@ should include image pull secrets when specified:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should include metrics port when metrics enabled:
@@ -245,7 +245,7 @@ should include metrics port when metrics enabled:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -309,7 +309,7 @@ should include metrics port when metrics enabled:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should include node selector when specified:
@@ -323,7 +323,7 @@ should include node selector when specified:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -389,7 +389,7 @@ should include node selector when specified:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should include pod annotations when specified:
@@ -403,7 +403,7 @@ should include pod annotations when specified:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -469,7 +469,7 @@ should include pod annotations when specified:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should include tolerations when specified:
@@ -483,7 +483,7 @@ should include tolerations when specified:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -547,7 +547,7 @@ should include tolerations when specified:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           tolerations:
             - effect: NoSchedule
@@ -566,7 +566,7 @@ should set custom replica count:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 3
@@ -630,7 +630,7 @@ should set custom replica count:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should set custom resources:
@@ -644,7 +644,7 @@ should set custom resources:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -708,7 +708,7 @@ should set custom resources:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should set pod security context:
@@ -722,7 +722,7 @@ should set pod security context:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -786,7 +786,7 @@ should set pod security context:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should set security context:
@@ -800,7 +800,7 @@ should set security context:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -864,7 +864,7 @@ should set security context:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should set termination grace period:
@@ -878,7 +878,7 @@ should set termination grace period:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -942,6 +942,6 @@ should set termination grace period:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []

--- a/helm/kmcp/tests/__snapshot__/integration_test.yaml.snap
+++ b/helm/kmcp/tests/__snapshot__/integration_test.yaml.snap
@@ -7,7 +7,7 @@ should create deployment when metrics enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -17,7 +17,7 @@ should create deployment when metrics enabled:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -25,7 +25,7 @@ should create deployment when metrics enabled:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -85,7 +85,7 @@ should create deployment with default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -95,7 +95,7 @@ should create deployment with default values:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -103,7 +103,7 @@ should create deployment with default values:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -163,7 +163,7 @@ should create deployment with minimal configuration:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -173,7 +173,7 @@ should create deployment with minimal configuration:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -181,7 +181,7 @@ should create deployment with minimal configuration:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -237,7 +237,7 @@ should include metrics port in deployment when metrics enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -247,7 +247,7 @@ should include metrics port in deployment when metrics enabled:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -255,7 +255,7 @@ should include metrics port in deployment when metrics enabled:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -315,7 +315,7 @@ should use custom namespace:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -325,7 +325,7 @@ should use custom namespace:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -333,7 +333,7 @@ should use custom namespace:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:
@@ -393,7 +393,7 @@ should use custom release name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-custom-release-controller
       namespace: NAMESPACE
@@ -403,7 +403,7 @@ should use custom release name:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kmcp
-          control-plane: controller-manager
+          control-plane: controller
       template:
         metadata:
           annotations:
@@ -411,7 +411,7 @@ should use custom release name:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kmcp
-            control-plane: controller-manager
+            control-plane: controller
         spec:
           containers:
             - args:

--- a/helm/kmcp/tests/__snapshot__/integration_test.yaml.snap
+++ b/helm/kmcp/tests/__snapshot__/integration_test.yaml.snap
@@ -9,7 +9,7 @@ should create deployment when metrics enabled:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -73,7 +73,7 @@ should create deployment when metrics enabled:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should create deployment with default values:
@@ -87,7 +87,7 @@ should create deployment with default values:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -151,7 +151,7 @@ should create deployment with default values:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should create deployment with minimal configuration:
@@ -165,7 +165,7 @@ should create deployment with minimal configuration:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -225,7 +225,7 @@ should create deployment with minimal configuration:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: default
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should include metrics port in deployment when metrics enabled:
@@ -239,7 +239,7 @@ should include metrics port in deployment when metrics enabled:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -303,7 +303,7 @@ should include metrics port in deployment when metrics enabled:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should use custom namespace:
@@ -317,7 +317,7 @@ should use custom namespace:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -381,7 +381,7 @@ should use custom namespace:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-controller
           terminationGracePeriodSeconds: 10
           volumes: []
 should use custom release name:
@@ -395,7 +395,7 @@ should use custom release name:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager
+      name: RELEASE-NAME-custom-release-controller
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -459,6 +459,6 @@ should use custom release name:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          serviceAccountName: RELEASE-NAME-kmcp-controller-manager
+          serviceAccountName: RELEASE-NAME-custom-release-controller
           terminationGracePeriodSeconds: 10
           volumes: []

--- a/helm/kmcp/tests/__snapshot__/rbac_test.yaml.snap
+++ b/helm/kmcp/tests/__snapshot__/rbac_test.yaml.snap
@@ -7,7 +7,7 @@ should create cluster role binding when RBAC enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller-rolebinding
     roleRef:
@@ -27,7 +27,7 @@ should create cluster role when RBAC enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller-role
     rules:
@@ -91,7 +91,7 @@ should create leader election role:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-leader-election-role
       namespace: NAMESPACE
@@ -136,7 +136,7 @@ should create leader election role binding:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-leader-election-rolebinding
       namespace: NAMESPACE
@@ -157,7 +157,7 @@ should create metrics auth cluster role:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-metrics-auth-role
     rules:
@@ -182,7 +182,7 @@ should create metrics auth cluster role binding:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-metrics-auth-rolebinding
     roleRef:
@@ -202,7 +202,7 @@ should create metrics reader cluster role:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-metrics-reader
     rules:
@@ -220,7 +220,7 @@ should create service account when enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE
@@ -233,7 +233,7 @@ should include mcpservers finalizers rules:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller-role
     rules:
@@ -297,7 +297,7 @@ should include mcpservers resource rules:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller-role
     rules:
@@ -361,7 +361,7 @@ should include mcpservers status rules:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller-role
     rules:
@@ -428,7 +428,7 @@ should include service account annotations when specified:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller
       namespace: NAMESPACE

--- a/helm/kmcp/tests/__snapshot__/rbac_test.yaml.snap
+++ b/helm/kmcp/tests/__snapshot__/rbac_test.yaml.snap
@@ -9,14 +9,14 @@ should create cluster role binding when RBAC enabled:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-manager-rolebinding
+      name: RELEASE-NAME-controller-rolebinding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: RELEASE-NAME-manager-role
+      name: RELEASE-NAME-controller-role
     subjects:
       - kind: ServiceAccount
-        name: RELEASE-NAME-kmcp-controller-manager
+        name: RELEASE-NAME-controller
         namespace: NAMESPACE
 should create cluster role when RBAC enabled:
   1: |
@@ -29,7 +29,7 @@ should create cluster role when RBAC enabled:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-manager-role
+      name: RELEASE-NAME-controller-role
     rules:
       - apiGroups:
           - ""
@@ -146,7 +146,7 @@ should create leader election role binding:
       name: RELEASE-NAME-leader-election-role
     subjects:
       - kind: ServiceAccount
-        name: RELEASE-NAME-kmcp-controller-manager
+        name: RELEASE-NAME-controller
         namespace: NAMESPACE
 should create metrics auth cluster role:
   1: |
@@ -191,7 +191,7 @@ should create metrics auth cluster role binding:
       name: RELEASE-NAME-metrics-auth-role
     subjects:
       - kind: ServiceAccount
-        name: RELEASE-NAME-kmcp-controller-manager
+        name: RELEASE-NAME-controller
         namespace: NAMESPACE
 should create metrics reader cluster role:
   1: |
@@ -222,7 +222,7 @@ should create service account when enabled:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-kmcp-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE
 should include mcpservers finalizers rules:
   1: |
@@ -235,7 +235,7 @@ should include mcpservers finalizers rules:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-manager-role
+      name: RELEASE-NAME-controller-role
     rules:
       - apiGroups:
           - ""
@@ -299,7 +299,7 @@ should include mcpservers resource rules:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-manager-role
+      name: RELEASE-NAME-controller-role
     rules:
       - apiGroups:
           - ""
@@ -363,7 +363,7 @@ should include mcpservers status rules:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-manager-role
+      name: RELEASE-NAME-controller-role
     rules:
       - apiGroups:
           - ""
@@ -430,5 +430,5 @@ should include service account annotations when specified:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-kmcp-controller-manager
+      name: RELEASE-NAME-controller
       namespace: NAMESPACE

--- a/helm/kmcp/tests/__snapshot__/service_test.yaml.snap
+++ b/helm/kmcp/tests/__snapshot__/service_test.yaml.snap
@@ -7,7 +7,7 @@ should create service when metrics enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller-metrics-service
       namespace: NAMESPACE
@@ -20,7 +20,7 @@ should create service when metrics enabled:
       selector:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
       type: ClusterIP
 should set custom service port:
   1: |
@@ -31,7 +31,7 @@ should set custom service port:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller-metrics-service
       namespace: NAMESPACE
@@ -44,7 +44,7 @@ should set custom service port:
       selector:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
       type: ClusterIP
 should set custom service type:
   1: |
@@ -55,7 +55,7 @@ should set custom service type:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller-metrics-service
       namespace: NAMESPACE
@@ -68,7 +68,7 @@ should set custom service type:
       selector:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
       type: LoadBalancer
 should set custom target port:
   1: |
@@ -79,7 +79,7 @@ should set custom target port:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
         helm.sh/chart: kmcp-0.1.0
       name: RELEASE-NAME-controller-metrics-service
       namespace: NAMESPACE
@@ -92,5 +92,5 @@ should set custom target port:
       selector:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kmcp
-        control-plane: controller-manager
+        control-plane: controller
       type: ClusterIP

--- a/helm/kmcp/tests/__snapshot__/service_test.yaml.snap
+++ b/helm/kmcp/tests/__snapshot__/service_test.yaml.snap
@@ -9,7 +9,7 @@ should create service when metrics enabled:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager-metrics-service
+      name: RELEASE-NAME-controller-metrics-service
       namespace: NAMESPACE
     spec:
       ports:
@@ -33,7 +33,7 @@ should set custom service port:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager-metrics-service
+      name: RELEASE-NAME-controller-metrics-service
       namespace: NAMESPACE
     spec:
       ports:
@@ -57,7 +57,7 @@ should set custom service type:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager-metrics-service
+      name: RELEASE-NAME-controller-metrics-service
       namespace: NAMESPACE
     spec:
       ports:
@@ -81,7 +81,7 @@ should set custom target port:
         app.kubernetes.io/name: kmcp
         control-plane: controller-manager
         helm.sh/chart: kmcp-0.1.0
-      name: RELEASE-NAME-controller-manager-metrics-service
+      name: RELEASE-NAME-controller-metrics-service
       namespace: NAMESPACE
     spec:
       ports:

--- a/helm/kmcp/values.yaml
+++ b/helm/kmcp/values.yaml
@@ -91,3 +91,9 @@ service:
   type: ClusterIP
   port: 8443
   targetPort: 8443
+
+# Override the name of the controller
+nameOverride: ""
+
+# Override the full name of the controller
+fullnameOverride: ""

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -56,14 +56,14 @@ var _ = ginkgo.Describe("Manager", ginkgo.Ordered, func() {
 		_, err = utils.Run(cmd)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to label namespace with restricted policy")
 
-		ginkgo.By("deploying the controller-manager using Helm")
+		ginkgo.By("deploying the controller using Helm")
 		cmd = exec.Command("helm", "install", "kmcp", "helm/kmcp",
 			"--namespace", namespace,
 			"--wait", "--timeout=5m",
 			"--set", fmt.Sprintf("image.repository=%s", getImageRepository(projectImage)),
 			"--set", fmt.Sprintf("image.tag=%s", getImageTag(projectImage)))
 		_, err = utils.Run(cmd)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to deploy the controller-manager using Helm")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to deploy the controller using Helm")
 	})
 
 	// After all tests have been executed, clean up by undeploying the controller using Helm
@@ -73,7 +73,7 @@ var _ = ginkgo.Describe("Manager", ginkgo.Ordered, func() {
 		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace)
 		_, _ = utils.Run(cmd)
 
-		ginkgo.By("undeploying the controller-manager using Helm")
+		ginkgo.By("undeploying the controller using Helm")
 		cmd = exec.Command("helm", "uninstall", "kmcp", "--namespace", namespace)
 		_, _ = utils.Run(cmd)
 
@@ -134,11 +134,11 @@ var _ = ginkgo.Describe("Manager", ginkgo.Ordered, func() {
 
 	ginkgo.Context("Manager", func() {
 		ginkgo.It("should run successfully", func() {
-			ginkgo.By("validating that the controller-manager pod is running as expected")
+			ginkgo.By("validating that the controller pod is running as expected")
 			verifyControllerUp := func(g gomega.Gomega) {
-				// Get the name of the controller-manager pod
+				// Get the name of the controller pod
 				cmd := exec.Command("kubectl", "get",
-					"pods", "-l", "control-plane=controller-manager",
+					"pods", "-l", "control-plane=controller",
 					"-o", "go-template={{ range .items }}"+
 						"{{ if not .metadata.deletionTimestamp }}"+
 						"{{ .metadata.name }}"+
@@ -147,11 +147,11 @@ var _ = ginkgo.Describe("Manager", ginkgo.Ordered, func() {
 				)
 
 				podOutput, err := utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to retrieve controller-manager pod information")
+				g.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to retrieve controller pod information")
 				podNames := utils.GetNonEmptyLines(podOutput)
 				g.Expect(podNames).To(gomega.HaveLen(1), "expected 1 controller pod running")
 				controllerPodName = podNames[0]
-				g.Expect(controllerPodName).To(gomega.ContainSubstring("controller-manager"))
+				g.Expect(controllerPodName).To(gomega.ContainSubstring("controller"))
 
 				// Validate the pod's status
 				cmd = exec.Command("kubectl", "get",
@@ -160,7 +160,7 @@ var _ = ginkgo.Describe("Manager", ginkgo.Ordered, func() {
 				)
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(output).To(gomega.Equal("Running"), "Incorrect controller-manager pod status")
+				g.Expect(output).To(gomega.Equal("Running"), "Incorrect controller pod status")
 			}
 			gomega.Eventually(verifyControllerUp).Should(gomega.Succeed())
 		})


### PR DESCRIPTION
This PR has a couple of helm-related cleanup tasks

1. Rename `controller-manager -> controller` to be in line with other of our projects.
2. Allow for name override of resources for sub-charting