### PR TITLE
Add KMCP CLI support for deploying mcp servers using npx 

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/cmd/kmcp/cmd/build.go
+++ b/cmd/kmcp/cmd/build.go
@@ -48,7 +48,7 @@ func init() {
 	buildCmd.Flags().StringVar(&buildPlatform, "platform", "", "Target platform (e.g., linux/amd64,linux/arm64)")
 }
 
-func runBuild(cmd *cobra.Command, args []string) error {
+func runBuild(_ *cobra.Command, _ []string) error {
 	// Determine build directory
 	buildDirectory := buildDir
 	if buildDirectory == "" {

--- a/cmd/kmcp/cmd/npx_deploy.go
+++ b/cmd/kmcp/cmd/npx_deploy.go
@@ -1,0 +1,210 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/kagent-dev/kmcp/api/v1alpha1"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+var npxDeployCmd = &cobra.Command{
+	Use:   "npx-deploy <server-name>",
+	Short: "Deploy an MCP server using npx",
+	Long: `Deploy an MCP server using npx to run Model Context Protocol servers.
+
+This command creates an MCPServer Custom Resource Definition (CRD) that runs
+an MCP server using npx. It's particularly useful for running MCP servers
+that are available as npm packages.
+
+The server name is required and will be used as the name of the MCPServer resource.
+
+Examples:
+  kmcp npx-deploy my-server                                 # Deploy with default settings
+  kmcp npx-deploy my-server --dry-run                       # Print YAML without deploying
+  kmcp npx-deploy my-server --namespace prod                # Deploy to prod namespace
+  kmcp npx-deploy my-server --image custom:tag              # Use custom image
+  kmcp npx-deploy my-server --args package1,package2        # Custom npx arguments
+  kmcp npx-deploy my-server --port 8080                     # Use custom port
+  kmcp npx-deploy my-server --env "KEY1=value1,KEY2=value2" # Set environment variables`,
+	Args: cobra.ExactArgs(1),
+	RunE: runNpxDeploy,
+}
+
+var (
+	// npx-deploy flags
+	npxDeployNamespace string
+	npxDeployDryRun    bool
+	npxDeployImage     string
+	npxDeployArgs      []string
+	npxDeployPort      int
+	npxDeployEnv       string
+)
+
+func init() {
+	rootCmd.AddCommand(npxDeployCmd)
+
+	// Get current namespace from kubeconfig
+	currentNamespace, err := getCurrentNamespaceFromKubeconfig()
+	if err != nil {
+		// Fallback to default if unable to get current namespace
+		currentNamespace = "default"
+	}
+
+	// npx-deploy flags
+	npxDeployCmd.Flags().StringVarP(&npxDeployNamespace, "namespace", "n", currentNamespace, "Kubernetes namespace")
+	npxDeployCmd.Flags().BoolVar(&npxDeployDryRun, "dry-run", false, "Print out the MCPServer yaml without deploying")
+	npxDeployCmd.Flags().StringVar(&npxDeployImage, "image", "docker.io/mcp/everything", "Docker image to use")
+	npxDeployCmd.Flags().StringSliceVar(&npxDeployArgs, "args", []string{"@modelcontextprotocol/server-github"}, "Arguments to pass to npx")
+	npxDeployCmd.Flags().IntVar(&npxDeployPort, "port", 3000, "MCP server container port")
+	npxDeployCmd.Flags().StringVar(&npxDeployEnv, "env", "", "Comma-separated environment variables (KEY1=value1,KEY2=value2)")
+}
+
+func runNpxDeploy(_ *cobra.Command, args []string) error {
+	serverName := args[0]
+
+	// Parse environment variables
+	envMap := parseCommaSeparatedEnvVars(npxDeployEnv)
+
+	// Create MCPServer
+	mcpServer := &v1alpha1.MCPServer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kagent.dev/v1alpha1",
+			Kind:       "MCPServer",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serverName,
+			Namespace: npxDeployNamespace,
+		},
+		Spec: v1alpha1.MCPServerSpec{
+			Deployment: v1alpha1.MCPServerDeployment{
+				Image: npxDeployImage,
+				Port:  uint16(npxDeployPort),
+				Cmd:   "npx",
+				Args:  npxDeployArgs,
+				Env:   envMap,
+			},
+			TransportType: v1alpha1.TransportTypeStdio,
+		},
+	}
+
+	// Convert to YAML
+	yamlData, err := yaml.Marshal(mcpServer)
+	if err != nil {
+		return fmt.Errorf("failed to marshal MCPServer to YAML: %w", err)
+	}
+
+	if npxDeployDryRun {
+		// Print YAML to stdout
+		fmt.Println(string(yamlData))
+		return nil
+	}
+
+	// Apply to cluster
+	return applyMCPServerToCluster(yamlData, mcpServer)
+}
+
+func parseCommaSeparatedString(input string) []string {
+	if input == "" {
+		return []string{}
+	}
+
+	// Split by comma and trim whitespace
+	parts := strings.Split(input, ",")
+	result := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			// Remove quotes if present
+			trimmed = strings.Trim(trimmed, "'\"")
+			result = append(result, trimmed)
+		}
+	}
+
+	return result
+}
+
+func parseCommaSeparatedEnvVars(input string) map[string]string {
+	if input == "" {
+		return map[string]string{}
+	}
+
+	result := make(map[string]string)
+	parts := strings.Split(input, ",")
+
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			// Split by first equals sign
+			keyValue := strings.SplitN(trimmed, "=", 2)
+			if len(keyValue) == 2 {
+				key := strings.TrimSpace(keyValue[0])
+				value := strings.TrimSpace(keyValue[1])
+				// Remove quotes if present
+				value = strings.Trim(value, "'\"")
+				result[key] = value
+			}
+		}
+	}
+
+	return result
+}
+
+func applyMCPServerToCluster(yamlData []byte, mcpServer *v1alpha1.MCPServer) error {
+	fmt.Printf("🚀 Applying MCPServer to cluster...\n")
+
+	// Check if kubectl is available
+	if err := checkKubectlAvailable(); err != nil {
+		return fmt.Errorf("kubectl is required for cluster deployment: %w", err)
+	}
+
+	// Create temporary file for kubectl apply
+	tmpFile, err := os.CreateTemp("", "mcpserver-*.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	// Write YAML content to temp file
+	if _, err := tmpFile.Write(yamlData); err != nil {
+		return fmt.Errorf("failed to write to temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	// Apply using kubectl
+	err = runKubectl("apply", "-f", tmpFile.Name())
+	if err != nil {
+		// Check for CRD not found error
+		if strings.Contains(err.Error(), "no matches for kind") {
+			return fmt.Errorf("MCPServer CRD not found. Please run 'kmcp install' first")
+		}
+		return fmt.Errorf("kubectl apply failed: %w", err)
+	}
+
+	fmt.Printf("✅ MCPServer '%s' applied successfully\n", mcpServer.Name)
+
+	// Wait for the deployment to be ready
+	fmt.Printf("⌛ Waiting for deployment '%s' to be ready...\n", mcpServer.Name)
+	if err := waitForDeployment(mcpServer.Name, mcpServer.Namespace, 2*time.Minute); err != nil {
+		return fmt.Errorf("deployment not ready: %w", err)
+	}
+
+	fmt.Printf("✅ Deployment '%s' is ready.\n", mcpServer.Name)
+	fmt.Printf("💡 Check status with: kubectl get mcpserver %s -n %s\n", mcpServer.Name, mcpServer.Namespace)
+	fmt.Printf("💡 View logs with: kubectl logs -l app.kubernetes.io/name=%s -n %s\n", mcpServer.Name, mcpServer.Namespace)
+	if mcpServer.Spec.Deployment.Port != 0 {
+		fmt.Printf("💡 Port-forward to the service with: "+
+			"kubectl port-forward service/%s %d:%d -n %s\n",
+			mcpServer.Name, mcpServer.Spec.Deployment.Port,
+			mcpServer.Spec.Deployment.Port, mcpServer.Namespace)
+	}
+
+	return nil
+}

--- a/cmd/kmcp/cmd/npx_deploy.go
+++ b/cmd/kmcp/cmd/npx_deploy.go
@@ -165,7 +165,6 @@ func applyMCPServerToCluster(yamlData []byte, mcpServer *v1alpha1.MCPServer) err
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
-	defer os.Remove(tmpFile.Name())
 
 	// Write YAML content to temp file
 	if _, err := tmpFile.Write(yamlData); err != nil {
@@ -177,6 +176,9 @@ func applyMCPServerToCluster(yamlData []byte, mcpServer *v1alpha1.MCPServer) err
 
 	// Apply using kubectl
 	err = runKubectl("apply", "-f", tmpFile.Name())
+	if err := os.Remove(tmpFile.Name()); err != nil {
+		fmt.Printf("failed to remove temp file: %v\n", err)
+	}
 	if err != nil {
 		// Check for CRD not found error
 		if strings.Contains(err.Error(), "no matches for kind") {

--- a/cmd/kmcp/cmd/npx_deploy.go
+++ b/cmd/kmcp/cmd/npx_deploy.go
@@ -61,7 +61,7 @@ func init() {
 	// npx-deploy flags
 	npxDeployCmd.Flags().StringVarP(&npxDeployNamespace, "namespace", "n", currentNamespace, "Kubernetes namespace")
 	npxDeployCmd.Flags().BoolVar(&npxDeployDryRun, "dry-run", false, "Print out the MCPServer yaml without deploying")
-	npxDeployCmd.Flags().StringVar(&npxDeployImage, "image", "docker.io/mcp/everything", "Docker image to use")
+	npxDeployCmd.Flags().StringVar(&npxDeployImage, "image", "node:24-alpine3.21", "Docker image to use")
 	npxDeployCmd.Flags().StringSliceVar(&npxDeployArgs, "args",
 		[]string{"@modelcontextprotocol/server-github"}, "Arguments to pass to npx")
 	npxDeployCmd.Flags().IntVar(&npxDeployPort, "port", 3000, "MCP server container port")

--- a/pkg/agentgateway/agentgateway_translator.go
+++ b/pkg/agentgateway/agentgateway_translator.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	agentGatewayContainerImage = "howardjohn/agentgateway:1752179558"
+	agentGatewayContainerImage = "ghcr.io/agentgateway/agentgateway:0.7.3-musl"
 )
 
 type Outputs struct {
@@ -84,10 +84,10 @@ func (t *agentGatewayTranslator) translateAgentGatewayDeployment(
 				Name:            "copy-binary",
 				Image:           agentGatewayContainerImage,
 				ImagePullPolicy: corev1.PullIfNotPresent,
-				Command:         []string{"sh"},
+				Command:         []string{},
 				Args: []string{
-					"-c",
-					"cp /usr/bin/agentgateway /agentbin/agentgateway",
+					"--copy-self",
+					"/agentbin/agentgateway",
 				},
 				VolumeMounts: []corev1.VolumeMount{{
 					Name:      "binary",
@@ -100,11 +100,11 @@ func (t *agentGatewayTranslator) translateAgentGatewayDeployment(
 				Image:           image,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
-					"sh",
+					"/agentbin/agentgateway",
 				},
 				Args: []string{
-					"-c",
-					"/agentbin/agentgateway -f /config/local.yaml",
+					"-f",
+					"/config/local.yaml",
 				},
 				EnvFrom: secretEnvFrom,
 				VolumeMounts: []corev1.VolumeMount{
@@ -150,10 +150,10 @@ func (t *agentGatewayTranslator) translateAgentGatewayDeployment(
 					Name:            "agent-gateway",
 					Image:           agentGatewayContainerImage,
 					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"sh"},
+					Command:         []string{},
 					Args: []string{
-						"-c",
-						"/usr/bin/agentgateway -f /config/local.yaml",
+						"--copy-self",
+						"/agentbin/agentgateway",
 					},
 					VolumeMounts: []corev1.VolumeMount{{
 						Name:      "config",
@@ -401,7 +401,6 @@ func (t *agentGatewayTranslator) translateAgentGatewayConfig(server *v1alpha1.MC
 							Backends: []RouteBackend{{
 								Weight: 100,
 								MCP: &MCPBackend{
-									Name:    mcpTarget.Name,
 									Targets: []MCPTarget{mcpTarget},
 								},
 							}},

--- a/pkg/agentgateway/agentgateway_types.go
+++ b/pkg/agentgateway/agentgateway_types.go
@@ -206,7 +206,6 @@ type Target struct {
 
 // MCPBackend represents an MCP backend
 type MCPBackend struct {
-	Name    string      `json:"name" yaml:"name"`
 	Targets []MCPTarget `json:"targets" yaml:"targets"`
 }
 


### PR DESCRIPTION
- Added a new command to the KMCP CLI which allows users to easily spin up a mcp server using npx ie: `kmcp npx-deploy <mcp_server_name>`. By default this command will create the following `McpServer` CRD and start the github mcp server. Default arguments can be overridden using the `--args` flag, and the default image can be overriden using the `--image` flag. The command also has the `--secrets` flag which allows users to specify the secret name to mount to the mcp server container allowing kubernetes secrets containing sensitive data ie: `GITHUB_PERSONAL_ACCESS_TOKEN` to be used by the mcp server.

```
  kind: MCPServer
  metadata:
    name: <mcp_server_name>
    namespace: default
  spec:
    deployment:
      args:
      - '@modelcontextprotocol/server-github'
      cmd: npx
      image: node:24-alpine3.21
      port: 3000
    transportType: stdio
```