### PR TITLE
fix: issue with installing crd chart

### DIFF
--- a/pkg/cli/internal/commands/utils.go
+++ b/pkg/cli/internal/commands/utils.go
@@ -62,9 +62,7 @@ func getLatestReleaseTag(repo string) (string, error) {
 		return "", err
 	}
 
-	if strings.HasPrefix(release.TagName, "v") {
-		release.TagName = strings.TrimPrefix(release.TagName, "v")
-	}
+	release.TagName = strings.TrimPrefix(release.TagName, "v")
 
 	return release.TagName, nil
 }

--- a/pkg/cli/internal/commands/utils.go
+++ b/pkg/cli/internal/commands/utils.go
@@ -61,6 +61,11 @@ func getLatestReleaseTag(repo string) (string, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
 		return "", err
 	}
+
+	if strings.HasPrefix(release.TagName, "v") {
+		release.TagName = strings.TrimPrefix(release.TagName, "v")
+	}
+
 	return release.TagName, nil
 }
 


### PR DESCRIPTION
- Fixes an issue with installing the CRD chart by removing the `v` prefix from the tag name.