### PR TITLE
feat(helm): add ability to override default resources name and namespace

### DIFF
--- a/helm/kmcp/templates/_helpers.tpl
+++ b/helm/kmcp/templates/_helpers.tpl
@@ -1,16 +1,17 @@
 {{/*
-Expand the name of the chart.
-*/}}
-{{- define "kmcp.name" -}}
-{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "kmcp.fullname" -}}
-{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- if not .Values.nameOverride }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -36,7 +37,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "kmcp.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "kmcp.name" . }}
+app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 control-plane: controller-manager
 {{- end }}
@@ -53,10 +54,11 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Create the namespace to use
+Expand the namespace of the release.
+Allows overriding it for multi-namespace deployments in combined charts.
 */}}
 {{- define "kmcp.namespace" -}}
-{{- .Release.Namespace }}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
 {{/*

--- a/helm/kmcp/templates/deployment.yaml
+++ b/helm/kmcp/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-controller-manager
+  name: {{ include "kmcp.fullname" . }}-controller-manager
   namespace: {{ include "kmcp.namespace" . }}
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}

--- a/helm/kmcp/templates/rbac/clusterrole.yaml
+++ b/helm/kmcp/templates/rbac/clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-manager-role
+  name: {{ include "kmcp.fullname" . }}-manager-role
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}
 rules:

--- a/helm/kmcp/templates/rbac/clusterrolebinding.yaml
+++ b/helm/kmcp/templates/rbac/clusterrolebinding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-manager-rolebinding
+  name: {{ include "kmcp.fullname" . }}-manager-rolebinding
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-manager-role
+  name: {{ include "kmcp.fullname" . }}-manager-role
 subjects:
 - kind: ServiceAccount
   name: {{ include "kmcp.serviceAccountName" . }}

--- a/helm/kmcp/templates/rbac/leader-election-role.yaml
+++ b/helm/kmcp/templates/rbac/leader-election-role.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-leader-election-role
+  name: {{ include "kmcp.fullname" . }}-leader-election-role
   namespace: {{ include "kmcp.namespace" . }}
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}

--- a/helm/kmcp/templates/rbac/leader-election-rolebinding.yaml
+++ b/helm/kmcp/templates/rbac/leader-election-rolebinding.yaml
@@ -3,14 +3,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-leader-election-rolebinding
+  name: {{ include "kmcp.fullname" . }}-leader-election-rolebinding
   namespace: {{ include "kmcp.namespace" . }}
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-leader-election-role
+  name: {{ include "kmcp.fullname" . }}-leader-election-role
 subjects:
 - kind: ServiceAccount
   name: {{ include "kmcp.serviceAccountName" . }}

--- a/helm/kmcp/templates/rbac/metrics-auth-clusterrole.yaml
+++ b/helm/kmcp/templates/rbac/metrics-auth-clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-metrics-auth-role
+  name: {{ include "kmcp.fullname" . }}-metrics-auth-role
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}
 rules:

--- a/helm/kmcp/templates/rbac/metrics-auth-clusterrolebinding.yaml
+++ b/helm/kmcp/templates/rbac/metrics-auth-clusterrolebinding.yaml
@@ -3,13 +3,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-metrics-auth-rolebinding
+  name: {{ include "kmcp.fullname" . }}-metrics-auth-rolebinding
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-metrics-auth-role
+  name: {{ include "kmcp.fullname" . }}-metrics-auth-role
 subjects:
 - kind: ServiceAccount
   name: {{ include "kmcp.serviceAccountName" . }}

--- a/helm/kmcp/templates/rbac/metrics-reader-clusterrole.yaml
+++ b/helm/kmcp/templates/rbac/metrics-reader-clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-metrics-reader
+  name: {{ include "kmcp.fullname" . }}-metrics-reader
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}
 rules:

--- a/helm/kmcp/templates/service.yaml
+++ b/helm/kmcp/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-controller-manager-metrics-service
+  name: {{ include "kmcp.fullname" . }}-controller-manager-metrics-service
   namespace: {{ include "kmcp.namespace" . }}
   labels:
     {{- include "kmcp.labels" . | nindent 4 }}

--- a/helm/kmcp/values.yaml
+++ b/helm/kmcp/values.yaml
@@ -2,6 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+nameOverride: ""
+fullnameOverride: ""
+
+# -- Override the namespace
+# @default -- `.Release.Namespace`
+namespaceOverride: ""
+
 # Image configuration
 image:
   repository: ghcr.io/kagent-dev/kmcp/controller


### PR DESCRIPTION
Adds ability to override `name`, `fullName`, and `namespace` as needed. This facilitates the use/deployment of this chart as a dependency within other charts (e.g. from within `kagent`).