### PR TITLE
fix(controller): MCPServer environment variables not passed to containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ go.work
 *~
 # helm
 dist/
+
+.cursor/

--- a/pkg/controller/internal/agentgateway/agentgateway_translator.go
+++ b/pkg/controller/internal/agentgateway/agentgateway_translator.go
@@ -333,7 +333,7 @@ func convertEnvVars(env map[string]string) []corev1.EnvVar {
 	if env == nil {
 		return nil
 	}
-	envVars := make([]corev1.EnvVar, len(env))
+	envVars := make([]corev1.EnvVar, 0, len(env))
 	for key, value := range env {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  key,

--- a/pkg/controller/internal/agentgateway/agentgateway_translator_test.go
+++ b/pkg/controller/internal/agentgateway/agentgateway_translator_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agentgateway
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestConvertEnvVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected []corev1.EnvVar
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty input",
+			input:    map[string]string{},
+			expected: []corev1.EnvVar{},
+		},
+		{
+			name: "single env var",
+			input: map[string]string{
+				"GRAFANA_URL": "http://grafana.grafana:3000",
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  "GRAFANA_URL",
+					Value: "http://grafana.grafana:3000",
+				},
+			},
+		},
+		{
+			name: "multiple env vars (sorted by name)",
+			input: map[string]string{
+				"ZZ_LAST":     "last",
+				"AA_FIRST":    "first",
+				"BB_MIDDLE":   "middle",
+				"GRAFANA_URL": "http://grafana.grafana:3000",
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  "AA_FIRST",
+					Value: "first",
+				},
+				{
+					Name:  "BB_MIDDLE",
+					Value: "middle",
+				},
+				{
+					Name:  "GRAFANA_URL",
+					Value: "http://grafana.grafana:3000",
+				},
+				{
+					Name:  "ZZ_LAST",
+					Value: "last",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertEnvVars(tt.input)
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("convertEnvVars() = %v, expected %v", result, tt.expected)
+			}
+
+			// Additional check: ensure no empty env vars are created
+			for _, envVar := range result {
+				if envVar.Name == "" {
+					t.Errorf("convertEnvVars() created an empty env var name, this indicates the original bug is still present")
+				}
+			}
+
+			// Verify length is correct
+			if len(result) != len(tt.input) {
+				t.Errorf("convertEnvVars() returned %d env vars, expected %d", len(result), len(tt.input))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the MCPServer controller where environment variables defined in `spec.deployment.env` were not being passed to deployed containers, causing MCP servers to fall back to default configurations instead of using the intended environment-specific settings.

## Root Cause

The issue was in the `convertEnvVars` function in `agentgateway_translator.go`. The function had a subtle but critical bug:

```go
// BEFORE (buggy):
envVars := make([]corev1.EnvVar, len(env))  // Creates slice with len(env) zero-value elements
for key, value := range env {
    envVars = append(envVars, corev1.EnvVar{  // append() adds AFTER the zero values!
        Name:  key,
        Value: value,
    })
}

// AFTER (fixed):
envVars := make([]corev1.EnvVar, 0, len(env))  // Creates empty slice with capacity len(env)
```

This caused the slice to contain empty `EnvVar` elements followed by the actual environment variables. When sorted, the empty variables (with empty names) would come first, effectively hiding the real environment variables.

The reason the correct environment variables become missing from the container is likely due to Kubernetes validation and processing. When Kubernetes encounters environment variables with empty names (""), it may reject the entire environment variable list.