### PR TITLE
[fix] Append `args` to STDIO Deployment of MCPServer

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/controller/internal/transportadapter/transportadapter_translator.go
+++ b/pkg/controller/internal/transportadapter/transportadapter_translator.go
@@ -84,6 +84,14 @@ func (t *transportAdapterTranslator) translateTransportAdapterDeployment(
 	var template corev1.PodSpec
 	switch server.Spec.TransportType {
 	case v1alpha1.TransportTypeStdio:
+		args := []string{
+			"-f",
+			"/config/local.yaml",
+		}
+		if server.Spec.Deployment.Args != nil {
+			args = append(args, server.Spec.Deployment.Args...)
+		}
+
 		// copy the binary into the container when running with stdio
 		template = corev1.PodSpec{
 			ServiceAccountName: server.Name,
@@ -108,10 +116,7 @@ func (t *transportAdapterTranslator) translateTransportAdapterDeployment(
 				Command: []string{
 					"/adapterbin/agentgateway",
 				},
-				Args: []string{
-					"-f",
-					"/config/local.yaml",
-				},
+				Args:    args,
 				Env:     convertEnvVars(server.Spec.Deployment.Env),
 				EnvFrom: secretEnvFrom,
 				VolumeMounts: []corev1.VolumeMount{

--- a/pkg/controller/mcpserver_controller_test.go
+++ b/pkg/controller/mcpserver_controller_test.go
@@ -90,6 +90,10 @@ var _ = ginkgo.Describe("MCPServer Controller", func() {
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+			ginkgo.By("verifying the deployment")
+			deployment := &appsv1.Deployment{}
+			gomega.Expect(k8sClient.Get(ctx, typeNamespacedName, deployment)).To(gomega.Succeed())
+			gomega.Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(gomega.HaveExactElements("-f", "/config/local.yaml", "-y", "@modelcontextprotocol/server-filesystem", "/"))
 		})
 	})
 


### PR DESCRIPTION
Brought up on the kagent side of things, creating a server with args was not appending the `deployment.args` to the deployment. Looking into translation code shows that we weren't appending the args to the `stdio` deployments.

I'm not sure if this was purposeful or a bug/oversight, so opening this up for more kmcp-knowledgable peeps.