### PR TITLE
use latest tag to fetch controller image

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -51,6 +51,10 @@ jobs:
         fi
         echo "Building Docker image with version: ${VERSION}"
         make docker-build VERSION=${VERSION}
+        
+        # Also tag and push as 'latest'
+        echo "Tagging and pushing as 'latest'..."
+        make docker-tag-latest VERSION=${VERSION}
   push-helm-chart:
     needs:
     - push-images

--- a/Makefile
+++ b/Makefile
@@ -85,15 +85,12 @@ helm-package: manifests
 	mkdir -p $(DIST_FOLDER)
 	@echo "Packaging Helm chart with version $(VERSION)..."
 	@cp helm/kmcp/Chart.yaml helm/kmcp/Chart.yaml.bak
-	@sed "s/^version: .*/version: $(VERSION)/" helm/kmcp/Chart.yaml.bak > helm/kmcp/Chart.yaml
+	@awk '/^version:/ { print; print "appVersion: \"$(VERSION)\""; next } { print }' helm/kmcp/Chart.yaml.bak > helm/kmcp/Chart.yaml
 	@helm package helm/kmcp --version $(VERSION) -d $(DIST_FOLDER)
 	@mv helm/kmcp/Chart.yaml.bak helm/kmcp/Chart.yaml
 	@echo "Helm package created: $(DIST_FOLDER)/kmcp-$(VERSION).tgz"
 	@cp config/crd/bases/kagent.dev_mcpservers.yaml helm/kmcp-crds/templates/mcpserver-crd.yaml
-	@cp helm/kmcp-crds/Chart.yaml helm/kmcp-crds/Chart.yaml.bak
-	@sed "s/^version: .*/version: $(VERSION)/" helm/kmcp-crds/Chart.yaml.bak > helm/kmcp-crds/Chart.yaml
 	@helm package helm/kmcp-crds --version $(VERSION) -d $(DIST_FOLDER)
-	@mv helm/kmcp-crds/Chart.yaml.bak helm/kmcp-crds/Chart.yaml
 	@echo "Helm package created: $(DIST_FOLDER)/kmcp-crds-$(VERSION).tgz"
 
 .PHONY: helm-cleanup

--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,14 @@ docker-build: ## Build docker image with the manager.
 	$(DOCKER_BUILDER) build $(DOCKER_BUILD_ARGS) -t ${CONTROLLER_IMG} .
 	- $(DOCKER_BUILDER) rm $(BUILDX_BUILDER_NAME)
 
+.PHONY: docker-tag-latest
+docker-tag-latest: ## Tag the built image as 'latest' and push it
+	@echo "Tagging image as 'latest'..."
+	@docker tag ${CONTROLLER_IMG} $(DOCKER_REGISTRY)/$(DOCKER_REPO)/$(CONTROLLER_IMAGE_NAME):latest
+	@echo "Pushing 'latest' tag..."
+	@docker push $(DOCKER_REGISTRY)/$(DOCKER_REPO)/$(CONTROLLER_IMAGE_NAME):latest
+	@echo "Latest tag pushed successfully"
+
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	$(DOCKER_BUILDER) push ${CONTROLLER_IMG}

--- a/helm/kmcp-crds/Chart.yaml
+++ b/helm/kmcp-crds/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kmcp-crds
 description: CRDs for KMCP (Kubernetes MCP Server Controller)
 type: application
-version: 0.1.6
+version: 1.0.0
 home: https://github.com/kagent-dev/kmcp
 sources:
   - https://github.com/kagent-dev/kmcp

--- a/helm/kmcp-crds/Chart.yaml
+++ b/helm/kmcp-crds/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kmcp-crds
 description: CRDs for KMCP (Kubernetes MCP Server Controller)
 type: application
-version: 0.1.0
+version: 0.1.6
 home: https://github.com/kagent-dev/kmcp
 sources:
   - https://github.com/kagent-dev/kmcp

--- a/helm/kmcp/Chart.yaml
+++ b/helm/kmcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kmcp
 description: A Helm chart for KMCP (Kubernetes MCP Server Controller)
 type: application
-version: 0.1.0
+version: 0.1.6
 home: https://github.com/kagent-dev/kmcp
 sources:
   - https://github.com/kagent-dev/kmcp

--- a/helm/kmcp/Chart.yaml
+++ b/helm/kmcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kmcp
 description: A Helm chart for KMCP (Kubernetes MCP Server Controller)
 type: application
-version: 0.0.0
+version: 1.0.0
 home: https://github.com/kagent-dev/kmcp
 sources:
   - https://github.com/kagent-dev/kmcp

--- a/helm/kmcp/Chart.yaml
+++ b/helm/kmcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kmcp
 description: A Helm chart for KMCP (Kubernetes MCP Server Controller)
 type: application
-version: 0.1.6
+version: 0.0.0
 home: https://github.com/kagent-dev/kmcp
 sources:
   - https://github.com/kagent-dev/kmcp

--- a/helm/kmcp/templates/_helpers.tpl
+++ b/helm/kmcp/templates/_helpers.tpl
@@ -66,6 +66,9 @@ Create the image reference
 */}}
 {{- define "kmcp.image" -}}
 {{- $tag := .Values.image.tag | default .Chart.Version }}
+{{- if eq $tag "" }}
+{{- $tag = .Chart.Version }}
+{{- end }}
 {{- printf "%s:%s" .Values.image.repository $tag }}
 {{- end }}
 

--- a/helm/kmcp/templates/_helpers.tpl
+++ b/helm/kmcp/templates/_helpers.tpl
@@ -18,7 +18,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create chart name and version as used by the chart label.
 */}}
 {{- define "kmcp.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- .Chart.Name }}
 {{- end }}
 
 {{/*
@@ -27,9 +27,6 @@ Common labels
 {{- define "kmcp.labels" -}}
 helm.sh/chart: {{ include "kmcp.chart" . }}
 {{ include "kmcp.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -65,10 +62,7 @@ Allows overriding it for multi-namespace deployments in combined charts.
 Create the image reference
 */}}
 {{- define "kmcp.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.Version }}
-{{- if eq $tag "" }}
-{{- $tag = .Chart.Version }}
-{{- end }}
+{{- $tag := .Values.image.tag | default "latest" }}
 {{- printf "%s:%s" .Values.image.repository $tag }}
 {{- end }}
 

--- a/helm/kmcp/templates/_helpers.tpl
+++ b/helm/kmcp/templates/_helpers.tpl
@@ -18,7 +18,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create chart name and version as used by the chart label.
 */}}
 {{- define "kmcp.chart" -}}
-{{- .Chart.Name }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -27,6 +27,9 @@ Common labels
 {{- define "kmcp.labels" -}}
 helm.sh/chart: {{ include "kmcp.chart" . }}
 {{ include "kmcp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -62,7 +65,7 @@ Allows overriding it for multi-namespace deployments in combined charts.
 Create the image reference
 */}}
 {{- define "kmcp.image" -}}
-{{- $tag := .Values.image.tag | default "latest" }}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion | default "latest" }}
 {{- printf "%s:%s" .Values.image.repository $tag }}
 {{- end }}
 

--- a/helm/kmcp/values.yaml
+++ b/helm/kmcp/values.yaml
@@ -13,9 +13,9 @@ namespaceOverride: ""
 image:
   repository: ghcr.io/kagent-dev/kmcp/controller
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is 'latest'.
+  # Overrides the image tag whose default is the chart's appVersion.
   # Set to a specific version (e.g., "v0.1.7") to pin to that version.
-  tag: "latest"
+  # tag: ""
 
 # Image pull secrets for private registries
 imagePullSecrets: []

--- a/helm/kmcp/values.yaml
+++ b/helm/kmcp/values.yaml
@@ -14,7 +14,8 @@ image:
   repository: ghcr.io/kagent-dev/kmcp/controller
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.1.0"
+  # If not specified, will use the chart version
+  tag: ""
 
 # Image pull secrets for private registries
 imagePullSecrets: []

--- a/helm/kmcp/values.yaml
+++ b/helm/kmcp/values.yaml
@@ -13,9 +13,9 @@ namespaceOverride: ""
 image:
   repository: ghcr.io/kagent-dev/kmcp/controller
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  # If not specified, will use the chart version
-  tag: ""
+  # Overrides the image tag whose default is 'latest'.
+  # Set to a specific version (e.g., "v0.1.7") to pin to that version.
+  tag: "latest"
 
 # Image pull secrets for private registries
 imagePullSecrets: []


### PR DESCRIPTION
Issue: #74 

instead of pinning to a fix version, use latest tag to fetch the correct image and that should also update in workflow

Test:
- current helm chart config
```
$ kmcp git:(fix-controller-version-helm-update) helm template test-release . | grep "image:"        
        image: ghcr.io/kagent-dev/kmcp/controller:latest
```
- override specific version
```
$ kmcp git:(fix-controller-version-helm-update) helm template test-release . --set image.tag="v0.1.7" | grep "image:"
        image: ghcr.io/kagent-dev/kmcp/controller:v0.1.7

```
and last
```
$  kmcp git:(fix-controller-version-helm-update) make helm-test
Running Helm chart unit tests...

### Chart [ kmcp ] helm/kmcp

 PASS  Test deployment template	helm/kmcp/tests/deployment_test.yaml
 PASS  Integration tests for KMCP helm chart	helm/kmcp/tests/integration_test.yaml
 PASS  Test RBAC templates	helm/kmcp/tests/rbac_test.yaml
 PASS  Test service template	helm/kmcp/tests/service_test.yaml

Charts:      1 passed, 1 total
Test Suites: 4 passed, 4 total
Tests:       38 passed, 38 total
Snapshot:    34 passed, 34 total
Time:        56.30318ms

Helm chart unit tests completed successfully
```