### PR TITLE
fix: correct export name in TypeScript tool template generation

### DIFF
--- a/pkg/cli/internal/frameworks/common/base_generator.go
+++ b/pkg/cli/internal/frameworks/common/base_generator.go
@@ -129,8 +129,10 @@ func (g *BaseGenerator) GenerateToolFile(filePath string, config templates.ToolC
 	// Prepare template data
 	toolName := config.ToolName
 	toolNamePascalCase := cases.Title(language.English).String(toolName)
+	toolNameCamelCase := strcase.LowerCamelCase(toolName)
 	data := map[string]interface{}{
 		"ToolName":           toolName,
+		"ToolNameCamelCase":  toolNameCamelCase,
 		"ToolNameTitle":      cases.Title(language.English).String(toolName),
 		"ToolNameUpper":      strings.ToUpper(toolName),
 		"ToolNameLower":      strings.ToLower(toolName),

--- a/pkg/cli/internal/frameworks/typescript/templates/src/tools/tool.ts.tmpl
+++ b/pkg/cli/internal/frameworks/typescript/templates/src/tools/tool.ts.tmpl
@@ -1,16 +1,16 @@
 import { z } from 'zod';
 
-const {{.ToolName}}Schema = z.object({
+const {{.ToolNameCamelCase}}Schema = z.object({
   // Define your tool parameters here
   // Example:
   // input: z.string().describe('Input parameter description'),
 });
 
-const {{.ToolName}} = {
+const {{.ToolNameCamelCase}} = {
   name: '{{.ToolName}}',
   description: '{{.Description}}',
-  inputSchema: {{.ToolName}}Schema,
-  handler: async (params: z.infer<typeof {{.ToolName}}Schema>) => {
+  inputSchema: {{.ToolNameCamelCase}}Schema,
+  handler: async (params: z.infer<typeof {{.ToolNameCamelCase}}Schema>) => {
     // Implement your tool logic here
     // Example:
     // const { input } = params;
@@ -22,4 +22,4 @@ const {{.ToolName}} = {
   },
 };
 
-export { {{.ToolName}} };
+export { {{.ToolNameCamelCase}} };


### PR DESCRIPTION
fix: #81 
The template now uses {{.ToolNameCamelCase}} for the exported symbol.
Generated tools match the import name automatically.
Running npm run dev after adding a new tool works without modification.

Before:
<img width="942" height="515" alt="Screenshot 2025-09-11 175829" src="https://github.com/user-attachments/assets/243f7bb1-0412-4246-b0d5-31235854151d" />

After:
<img width="947" height="551" alt="Screenshot 2025-09-11 221318" src="https://github.com/user-attachments/assets/4df8b794-834f-4390-ae08-89b3d0b22867" />

