### PR TITLE
fix(cli): fix generated Go MCP server run and doc

### DIFF
--- a/pkg/cli/internal/commands/run.go
+++ b/pkg/cli/internal/commands/run.go
@@ -168,11 +168,11 @@ func runMCPGo(projectDir string, manifest *manifest.ProjectManifest) error {
 
 	if noInspector {
 		// Run the server directly
-		fmt.Printf("Running server directly: go run main.go\n")
+		fmt.Printf("Running server directly: go run cmd/server/main.go\n")
 		fmt.Printf("Server is running and waiting for MCP protocol input on stdin...\n")
 		fmt.Printf("Press Ctrl+C to stop the server\n")
 
-		serverCmd := exec.Command("go", "run", "main.go")
+		serverCmd := exec.Command("go", "run", "cmd/server/main.go")
 		serverCmd.Dir = projectDir
 		serverCmd.Stdout = os.Stdout
 		serverCmd.Stderr = os.Stderr
@@ -183,7 +183,7 @@ func runMCPGo(projectDir string, manifest *manifest.ProjectManifest) error {
 	// Create server configuration for inspector
 	serverConfig := map[string]interface{}{
 		"command": "go",
-		"args":    []string{"run", "main.go"},
+		"args":    []string{"run", "cmd/server/main.go"},
 	}
 
 	// Create MCP inspector config

--- a/pkg/cli/internal/frameworks/golang/generator.go
+++ b/pkg/cli/internal/frameworks/golang/generator.go
@@ -61,7 +61,7 @@ func (g *Generator) GenerateTool(projectroot string, config templates.ToolConfig
 	fmt.Printf("\nNext steps:\n")
 	fmt.Printf("1. Edit internal/tools/%s.go to implement your tool logic\n", toolNameSnakeCase)
 	fmt.Printf("2. Configure any required environment variables in kmcp.yaml\n")
-	fmt.Printf("3. Run 'go run main.go' to start the server\n")
+	fmt.Printf("3. Run 'go run cmd/server/main.go' to start the server\n")
 
 	return nil
 }

--- a/pkg/cli/internal/frameworks/golang/templates/README.md.tmpl
+++ b/pkg/cli/internal/frameworks/golang/templates/README.md.tmpl
@@ -20,7 +20,7 @@ This project was generated with [`kmcp`](https://github.com/kagent-dev/kmcp).
 
 2.  **Run the server:**
     ```bash
-    go run main.go
+    go run cmd/server/main.go
     ```
 
 ### Building the Docker Image
@@ -51,4 +51,4 @@ To add a new tool to your project, use the `kmcp add-tool` command:
 kmcp add-tool <tool-name>
 ```
 
-This will generate a new Go file in the `tools/` directory with a template for your new tool. You will need to add the new tool to the `main.go` file. 
+This will generate a new Go file in the `internal/tools/` directory with a template for your new tool. You will need to add the new tool to the `main.go` file.


### PR DESCRIPTION
This fixes the kmcp run command for mcp servers generated with kmcp init go and updates the generated README with the accurate file paths

### Before these change
kmcp run results in the following error
```
Running server directly: go run main.go
Server is running and waiting for MCP protocol input on stdin...
Press Ctrl+C to stop the server
stat main.go: no such file or directory
Error: exit status 1
```
### After these changes
- Docs reference the proper file paths
- `kmcp run` uses the right path to main.go to start the server
- The mcp inspector server config uses the right path to main.go