### PR TITLE
fix(controller): show correct status for MCPServer resource

### DIFF
--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -196,9 +196,14 @@ type HTTPTransportTLS struct {
 
 // MCPServerStatus defines the observed state of MCPServer.
 type MCPServerStatus struct {
+	// DisplayStatus shows a human-readable status of the MCPServer.
+	// Possible values: "Not Ready", "Ready", "Deleting"
+	// +optional
+	DisplayStatus string `json:"displayStatus,omitempty"`
+
 	// Conditions describe the current conditions of the MCPServer.
 	// Implementations should prefer to express MCPServer conditions
-	// using the `MCPServerConditionType` and `MCPServerConditionReason`
+	// using the MCPServerConditionType and MCPServerConditionReason
 	// constants so that operators and tools can converge on a common
 	// vocabulary to describe MCPServer state.
 	//
@@ -398,6 +403,7 @@ type ServiceAccountConfig struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=mcps;mcp
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.displayStatus"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:categories=kagent

--- a/pkg/controller/mcpserver_controller.go
+++ b/pkg/controller/mcpserver_controller.go
@@ -198,6 +198,25 @@ func (r *MCPServerReconciler) reconcileStatus(
 		}
 	}
 
+	// Set human-readable DisplayStatus based on deletion timestamp and Ready condition
+	if !server.DeletionTimestamp.IsZero() {
+		server.Status.DisplayStatus = "Deleting"
+	} else {
+		readyCondition := false
+		for _, condition := range server.Status.Conditions {
+			if condition.Type == string(kagentdevv1alpha1.MCPServerConditionReady) &&
+				condition.Status == metav1.ConditionTrue {
+				readyCondition = true
+				break
+			}
+		}
+		if readyCondition {
+			server.Status.DisplayStatus = "Ready"
+		} else {
+			server.Status.DisplayStatus = "Not Ready"
+		}
+	}
+
 	// Update the status
 	if err := r.Status().Update(ctx, server); err != nil {
 		log.FromContext(ctx).Error(err, "Failed to update MCPServer status")


### PR DESCRIPTION
## Summary
Add `DisplayStatus` field to `MCPServerStatus` to show human-readable status during pod creation and deletion, consistent with how Agent resources behave in kagent.

## Changes
- Add `DisplayStatus` field to `MCPServerStatus` struct
- Add `Status` print column to `kubectl get mcpserver` output
- Set `Not Ready` status while pod is being created
- Set `Deleting` status while resource is being deleted
- Set `Ready` status when deployment is fully available

## Reference Implementation
kagent-dev/kagent#737 (same pattern applied to MCPServer)

## Testing
- `go build ./...` passes cleanly

## Related Issue
Fixes #68