### PR TITLE
docs(python): fix incorrect CLI args in Python project README template

### DIFF
--- a/pkg/cli/internal/frameworks/python/templates/README.md.tmpl
+++ b/pkg/cli/internal/frameworks/python/templates/README.md.tmpl
@@ -82,7 +82,7 @@ tests/                  # Generated tests
 
 3. **Deploy to Kubernetes**:
    ```bash
-   kmcp deploy mcp --apply
+   kmcp deploy
    ```
 
 4. **Add New Tools**:
@@ -214,7 +214,7 @@ docker run -i {{.ProjectName}}:latest
 
 ```bash
 # Deploy to Kubernetes
-kmcp deploy mcp --apply
+kmcp deploy
 
 # Check deployment status
 kubectl get mcpserver {{.ProjectName}}


### PR DESCRIPTION
## Summary
The Python project README template referenced `kmcp deploy mcp --apply` which is not a valid command. The correct command is `kmcp deploy`.

## Changes
- Fixed `kmcp deploy mcp --apply` → `kmcp deploy` in Option 2 (Docker-Only Development) section
- Fixed `kmcp deploy mcp --apply` → `kmcp deploy` in Deployment (Kubernetes) section

## Testing
Documentation-only change. No code modified.

## Related Issue
Fixes #89