### PR TITLE
fix(samples): correct env and secretRefs format in production security sample

### DIFF
--- a/config/samples/mcpserver-production-security.yaml
+++ b/config/samples/mcpserver-production-security.yaml
@@ -118,20 +118,8 @@ spec:
     
     # Environment variables
     env:
-      - name: LOG_LEVEL
-        value: "info"
-      - name: MCP_SERVER_PORT
-        value: "8080"
+      LOG_LEVEL: "info"
+      MCP_SERVER_PORT: "8080"
     
-    # Reference to secrets for environment variables
     secretRefs:
       - name: mcp-server-secrets
-        key: API_KEY
-        envName: MCP_API_KEY
-
-  # MCP server configuration
-  mcpServer:
-    name: "secure-mcp-server"
-    args:
-      - "--port"
-      - "8080"


### PR DESCRIPTION
## Summary
The `mcpserver-production-security.yaml` sample had incorrect field formats that would cause users to create invalid MCPServer resources.

## Issues Fixed

1. **`env` wrong format** — sample used `[]corev1.EnvVar` (list with `name`/`value`) but `MCPServerDeployment.Env` is defined as `map[string]string`
2. **`secretRefs` wrong fields** — sample had non-existent `key` and `envName` fields; actual type is `[]corev1.LocalObjectReference` which only has `name`
3. **Non-existent `mcpServer` section** — removed stale spec section that doesn't exist in the CRD

## Impact
Users following this sample would get validation errors when applying to a cluster.

## Testing
Documentation/sample only change. Verified field types against `api/v1alpha1/mcpserver_types.go`.

## Related Issue
Related to #93